### PR TITLE
Add support for left and right padding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-module.exports = function padString(str, length, char = ' ') {
+module.exports = function padString(str, length, char = ' ', direction = 'left') {
     if (str.length >= length) return str;
     const padding = char.repeat(length - str.length);
-    return padding + str;
+    return direction === 'left' ? padding + str : str + padding;
 };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const padString = require('./index');
+
+describe('padString', function() {
+  it('should pad the string with spaces by default', function() {
+    assert.strictEqual(padString('test', 8), '    test');
+  });
+
+  it('should pad the string with the specified character', function() {
+    assert.strictEqual(padString('test', 8, '-', 'left'), '----test');
+    assert.strictEqual(padString('test', 8, '-', 'right'), 'test----');
+  });
+
+  it('should pad the string with the specified character', function() {
+    assert.strictEqual(padString('test', 8, '-'), '----test');
+  });
+
+  it('should return the string unchanged if it is already long enough', function() {
+    assert.strictEqual(padString('test', 4), 'test');
+  });
+});


### PR DESCRIPTION
This PR updates the padding function to support both left and right padding. A new `direction` parameter has been added to specify whether the padding should be applied to the left or right side of the string.