### PR TITLE
Fix padding direction bug in padString function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function padString(str, length, char = ' ', direction = 'left') {
     if (str.length >= length) return str;
     const padding = char.repeat(length - str.length);
-    return direction === 'right' ? padding + str : str + padding;
+    return direction === 'right' ? str + padding : padding + str;
 };


### PR DESCRIPTION
This PR fixes a bug in the `padString` function where the padding direction was reversed. The function now correctly pads the string based on the specified direction parameter.