### PR TITLE
feat: add function to pad paragraph with newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,17 @@ function padStr(str, length, char, isRightPad) {
     return isRightPad ? str + padding : padding + str;
 }
 
+function padParagraph(str, numLines = 2) {
+    const newLines = '\n'.repeat(numLines);
+    return newLines + str + newLines;
+}
+
 module.exports = {
     strPadLeft: function(str, length, char = ' ') {
         return padStr(str, length, char, false);
     },
     strPadRight: function(str, length, char = ' ') {
         return padStr(str, length, char, true);
-    }
+    },
+    padParagraph: padParagraph
 };


### PR DESCRIPTION
This PR introduces a new function `padParagraph` that adds a specified number of newlines before and after a given paragraph. This feature is helpful for formatting output where paragraphs need to be separated by blank lines.

### Changes:
- Added `padParagraph` function in `index.js`
- Updated `index.js` to include this new feature

### Testing:
- Ensure to add relevant test cases in `test.js` for validating this new feature.